### PR TITLE
Fix bugs and inefficiencies identified in pipeline review

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Missingness thresholds:
 - `max_missing_fraction` is a fraction of samples allowed to be missing.
 - If both are set, the workflow uses the stricter threshold.
 - The fraction is converted to a count with downward truncation. For example, with 10 samples, `0.15` allows `1` missing sample.
+- **If neither is set, the default is 0 — any site where even one sample is unaligned or missing is masked.** Set one of these options explicitly if you want to retain sites with partial coverage.
 
 Indel masking behavior:
 

--- a/Snakefile
+++ b/Snakefile
@@ -213,7 +213,7 @@ rule prepare_reference:
         """
         set -euo pipefail
         mkdir -p "$(dirname "{output.ref}")"
-        cp "{input.ref}" "{output.ref}"
+        ln -s "$(realpath "{input.ref}")" "{output.ref}"
         """
 
 

--- a/profiles/slurm/config.yaml
+++ b/profiles/slurm/config.yaml
@@ -15,4 +15,4 @@ latency-wait: 60
 # Override per-rule by adding resources in the Snakefile.
 default-resources:
   - mem_mb=20000
-  - time=2880
+  - time="48:00:00"

--- a/scripts/maf_to_sites.py
+++ b/scripts/maf_to_sites.py
@@ -105,7 +105,34 @@ def maf_path_for_sample(maf_dir: Path, sample: str) -> Path:
     raise FileNotFoundError(f"Missing MAF for sample '{sample}' under {maf_dir}")
 
 
+def _read_fai_entry(fai_path: Path, contig: str) -> tuple[int, int, int, int] | None:
+    """Return (length, offset, linebases, linewidth) for a contig from a .fai file."""
+    with fai_path.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            parts = line.rstrip("\n").split("\t")
+            if len(parts) >= 5 and parts[0] == contig:
+                return int(parts[1]), int(parts[2]), int(parts[3]), int(parts[4])
+    return None
+
+
 def read_contig_sequence(reference_fasta: Path, contig: str) -> str:
+    fai_path = Path(str(reference_fasta) + ".fai")
+    if fai_path.exists() and not str(reference_fasta).endswith(".gz"):
+        entry = _read_fai_entry(fai_path, contig)
+        if entry is not None:
+            length, offset, linebases, linewidth = entry
+            full_lines, remainder = divmod(length, linebases)
+            total_bytes = full_lines * linewidth + remainder
+            with open(reference_fasta, "rb") as fh:
+                fh.seek(offset)
+                raw = fh.read(total_bytes)
+            seq = raw.replace(b"\r", b"").replace(b"\n", b"")
+            if len(seq) != length:
+                raise ValueError(
+                    f"FAI seek returned {len(seq)} bases for '{contig}', expected {length}"
+                )
+            return seq.decode("ascii").upper()
+    # Fallback: linear scan (handles .gz or missing .fai)
     seq_parts: list[str] = []
     current: str | None = None
     with open_text(reference_fasta, "rt", errors="ignore") as handle:
@@ -359,12 +386,9 @@ def main() -> None:
             treat_n_as_missing=args.treat_n_as_missing,
         )
         sample_arrays.append(calls)
-        for idx, flag in enumerate(sample_indels):
-            if flag:
-                indel_flags[idx] = 1
-        for idx, flag in enumerate(sample_adjacent_indels):
-            if flag:
-                adjacent_indel_flags[idx] = 1
+        for i in range(len(sample_indels)):
+            indel_flags[i] |= sample_indels[i]
+            adjacent_indel_flags[i] |= sample_adjacent_indels[i]
 
     allowed_missing = missing_threshold(
         len(samples),

--- a/tests/test_workflow.py
+++ b/tests/test_workflow.py
@@ -1,4 +1,5 @@
 import importlib.util
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -31,13 +32,18 @@ def _run_snakemake(tmp_path: Path, config: Path | None, *targets: str) -> subpro
     ]
     if config is not None:
         cmd.extend(["--configfile", str(config)])
-    cmd.extend(targets)
+    cmd.extend(["--", *targets])
+    # Ensure tools (samtools, etc.) from the active conda env are on PATH
+    env = os.environ.copy()
+    env_bin = str(Path(sys.executable).parent)
+    env["PATH"] = env_bin + os.pathsep + env.get("PATH", "")
     return subprocess.run(
         cmd,
         cwd=repo_root,
         text=True,
         capture_output=True,
         check=False,
+        env=env,
     )
 
 


### PR DESCRIPTION
- README: clarify that missing threshold default is 0 (all partial sites masked)
- Snakefile: symlink reference instead of copying to avoid duplicating large genomes
- Snakefile/slurm profile: standardize time format to HH:MM:SS throughout
- maf_to_sites.py: use FAI index for O(1) contig sequence extraction instead of scanning the entire FASTA per contig job; fall back to linear scan for .gz
- maf_to_sites.py: replace slow enumerate loops for indel flag merging with single-pass |= loop over range
- tests: fix snakemake 9 compatibility (-- before targets, PATH propagation)